### PR TITLE
Use correct separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -2,15 +2,15 @@
 # Datatypes               (KEYWORD1)
 #######################################
 
-MAX31855                   KEYWORD1
+MAX31855	KEYWORD1
 
 #######################################
 # Methods and Functions   (KEYWORD2)
 #######################################
 
-begin                      KEYWORD2
-detectThermocouple         KEYWORD2
-getChipID                  KEYWORD2
-getTemperature             KEYWORD2
-getColdJunctionTemperature KEYWORD2
-readRawData                KEYWORD2
+begin	KEYWORD2
+detectThermocouple	KEYWORD2
+getChipID	KEYWORD2
+getTemperature	KEYWORD2
+getColdJunctionTemperature	KEYWORD2
+readRawData	KEYWORD2


### PR DESCRIPTION
The Arduino IDE currently requires the use of a tab separator between the name and identifier. Without this tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords