### PR TITLE
Added possibility to use other SPI device

### DIFF
--- a/src/MAX31855.cpp
+++ b/src/MAX31855.cpp
@@ -232,7 +232,7 @@ int32_t MAX31855::readRawData(void)
 
   delay(MAX31855_CONVERSION_TIME);
 
-  MAXSPI->beginTransaction(SPISettings(5000000, MSBFIRST, SPI_MODE0)); //up to 5MHz, read MSB first, SPI mode 0, see note
+  MAXSPI->beginTransaction(SPISettings(500000, MSBFIRST, SPI_MODE0)); //up to 5MHz, read MSB first, SPI mode 0, see note
 
   digitalWrite(_cs, LOW);                                          //set software CS low to enable SPI interface for MAX31855
 

--- a/src/MAX31855.h
+++ b/src/MAX31855.h
@@ -14,7 +14,7 @@
      near the converter because this may produce an errors.
    - It is strongly recommended to add a 10nF/0.01mF ceramic surface-mount capacitor, placed across
      the T+ and T- pins, to filter noise on the thermocouple lines.
-     
+
    written by : enjoyneering79
    sourse code: https://github.com/enjoyneering/MAX31855
 
@@ -60,9 +60,7 @@
 #include <avr/pgmspace.h>                  //use for PROGMEM Arduino STM32
 #endif
 
-#ifndef  MAX31855_SOFT_SPI                 //enable upload hw driver spi.h
 #include <SPI.h>
-#endif
 
 
 #define MAX31855_CONVERSION_POWER_UP_TIME   200    //in milliseconds
@@ -87,15 +85,15 @@ class MAX31855
   public:
    MAX31855(uint8_t cs);
 
-           void     begin(void);
+           void     begin(SPIClass *SPI_pointer = &SPI);
            uint8_t  detectThermocouple(int32_t rawValue = MAX31855_FORCE_READ_DATA);
            uint16_t getChipID(int32_t rawValue = MAX31855_FORCE_READ_DATA);
            float    getTemperature(int32_t rawValue = MAX31855_FORCE_READ_DATA);
            float    getColdJunctionTemperature(int32_t rawValue = MAX31855_FORCE_READ_DATA);
    virtual int32_t  readRawData(void);
- 
-  private:
 
+  private:
+   SPIClass * MAXSPI = NULL;
   protected:
    uint8_t _cs;
 };


### PR DESCRIPTION
This is small change, that does not affect currently working scripts, that allow to use another SPI device - except default one.
ESP32 has three of them - if you already use default SPI for something else - there was no way to use any other in this library.
With this change, you can do nothing - and everything work's as before, or you can declare new SPI device and pass it to the object.
```
SPIClass *ESP32_SPI = new SPIClass(HSPI);
/* start MAX31855 */
myMAX31855.begin(ESP32_SPI);
```